### PR TITLE
Update decople.py

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -243,6 +243,11 @@ class AutoConfig(object):
             self._load(self.search_path or self._caller_path())
 
         return self.config(*args, **kwargs)
+    
+    def get(self, *args, **kwargs):
+        if not self.config:
+            self._load(self.search_path or self._caller_path())
+        return self.config(*args, **kwargs)
 
 
 # A pré-instantiated AutoConfig to improve decouple's usability


### PR DESCRIPTION
Added a method called get() in AutoConfig class. It will basically produce the same results as calling config() object, but more intuitive because get is an action. Therefore instead of just calling config object, we call config's get method: config.get()